### PR TITLE
added overrides and variables to setup.cfg/manifest.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -8,3 +8,5 @@ recursive-include oarepo_dashboard *.js
 recursive-include oarepo_dashboard *.jsx
 recursive-include oarepo_dashboard *.less
 recursive-include oarepo_dashboard *.jinja
+recursive-include oarepo_dashboard *.variables
+recursive-include oarepo_dashboard *.overrides

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = oarepo-dashboard
-version = 1.0.4
+version = 1.0.5
 description = Support for user dashboard (records, communities, requests)
 authors = Mirek Simek <miroslav.simek@cesnet.cz>
 readme = README.md
@@ -8,7 +8,7 @@ long_description = file:README.md
 long_description_content_type = text/markdown
 
 [options]
-python = >=3.9
+python = >=3.10
 install_requires =
     oarepo-runtime>=1.4.44
     openpyxl

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,7 +32,7 @@ exclude =
     tests
 
 [options.package_data]
-* = *.json, *.rst, *.md, *.json5, *.jinja2, *.po, *.mo, *.pot, *.js, *.jsx, *.less, *.jinja
+* = *.json, *.rst, *.md, *.json5, *.jinja2, *.po, *.mo, *.pot, *.js, *.jsx, *.less, *.jinja, *.overrides, *.variables
 
 [options.entry_points]
 invenio_base.blueprints =


### PR DESCRIPTION
Fixed issue with overrides and variables files not being included into the package. Tested local build of wheel after adding them to manifest and setup.cfg and they are now included. 