### PR TITLE
using dynamiclistitem

### DIFF
--- a/oarepo_dashboard/ui/dashboard_communities/__init__.py
+++ b/oarepo_dashboard/ui/dashboard_communities/__init__.py
@@ -4,6 +4,7 @@ from oarepo_ui.resources.config import (
 from oarepo_ui.resources.resource import RecordsUIResource
 from flask_menu import current_menu
 from oarepo_runtime.i18n import lazy_gettext as _
+from flask_security import login_required
 
 
 class DashboardCommunitiesUIResourceConfig(RecordsUIResourceConfig):
@@ -13,7 +14,7 @@ class DashboardCommunitiesUIResourceConfig(RecordsUIResourceConfig):
     application_id = "communities_dashboard"
     templates = {
         "search": "DashboardCommunitiesPage",
-    }   
+    }
 
     routes = {
         "search": "/",
@@ -25,7 +26,9 @@ class DashboardCommunitiesUIResourceConfig(RecordsUIResourceConfig):
 
 
 class DashboardCommunitiesUIResource(RecordsUIResource):
-    pass
+    @login_required
+    def search(self):
+        return super().search()
 
 
 def create_blueprint(app):

--- a/oarepo_dashboard/ui/dashboard_records/__init__.py
+++ b/oarepo_dashboard/ui/dashboard_records/__init__.py
@@ -9,6 +9,7 @@ from oarepo_ui.resources import PermissionsComponent
 from oarepo_dashboard.ui.dashboard_components.search import (
     DashboardRecordsSearchComponent,
 )
+from flask_security import login_required
 
 
 class DashboardRecordsUIResourceConfig(GlobalSearchUIResourceConfig):
@@ -32,7 +33,9 @@ class DashboardRecordsUIResourceConfig(GlobalSearchUIResourceConfig):
 
 
 class DashboardRecordsUIResource(GlobalSearchUIResource):
-    pass
+    @login_required
+    def search(self):
+        return super().search()
 
 
 def create_blueprint(app):

--- a/oarepo_dashboard/ui/dashboard_requests/__init__.py
+++ b/oarepo_dashboard/ui/dashboard_requests/__init__.py
@@ -26,6 +26,9 @@ class DashboardRequestsUIResourceConfig(RecordsUIResourceConfig):
 
     components = [DashboardRequestsSearchComponent]
 
+    # object where we can store default result list items for various requests types
+    default_results_list_items = {}
+
     def search_endpoint_url(self, identity, api_config, overrides={}, **kwargs):
         return "/api/user/requests"
 
@@ -34,7 +37,8 @@ class DashboardRequestsUIResourceConfig(RecordsUIResourceConfig):
         requests_result_list_items = current_app.config.get(
             "REQUESTS_RESULT_LIST_ITEMS", {}
         )
-        return requests_result_list_items
+        # make it possible to override these components from invenio.cfg
+        return {**self.default_results_list_items, **requests_result_list_items}
 
 
 class DashboardRequestsUIResource(RecordsUIResource):

--- a/oarepo_dashboard/ui/dashboard_requests/__init__.py
+++ b/oarepo_dashboard/ui/dashboard_requests/__init__.py
@@ -7,6 +7,7 @@ from oarepo_runtime.i18n import lazy_gettext as _
 from oarepo_dashboard.ui.dashboard_components.search import (
     DashboardRequestsSearchComponent,
 )
+from flask import current_app
 
 
 class DashboardRequestsUIResourceConfig(RecordsUIResourceConfig):
@@ -27,6 +28,13 @@ class DashboardRequestsUIResourceConfig(RecordsUIResourceConfig):
 
     def search_endpoint_url(self, identity, api_config, overrides={}, **kwargs):
         return "/api/user/requests"
+
+    @property
+    def default_components(self):
+        requests_result_list_items = current_app.config.get(
+            "REQUESTS_RESULT_LIST_ITEMS", {}
+        )
+        return requests_result_list_items
 
 
 class DashboardRequestsUIResource(RecordsUIResource):

--- a/oarepo_dashboard/ui/dashboard_requests/__init__.py
+++ b/oarepo_dashboard/ui/dashboard_requests/__init__.py
@@ -8,6 +8,7 @@ from oarepo_dashboard.ui.dashboard_components.search import (
     DashboardRequestsSearchComponent,
 )
 from flask import current_app
+from flask_security import login_required
 
 
 class DashboardRequestsUIResourceConfig(RecordsUIResourceConfig):
@@ -42,7 +43,9 @@ class DashboardRequestsUIResourceConfig(RecordsUIResourceConfig):
 
 
 class DashboardRequestsUIResource(RecordsUIResource):
-    pass
+    @login_required
+    def search(self):
+        return super().search()
 
 
 def create_blueprint(app):

--- a/oarepo_dashboard/ui/dashboard_requests/semantic-ui/js/dashboard_requests/search/RequestTypeSpecificComponents.jsx
+++ b/oarepo_dashboard/ui/dashboard_requests/semantic-ui/js/dashboard_requests/search/RequestTypeSpecificComponents.jsx
@@ -10,13 +10,12 @@ import {
 } from "./icons/TypeIcons";
 
 export const requestTypeSpecificComponents = {
-  [`RequestTypeLabel.layout.documents_edit_record`]: LabelTypeEditRecord,
-  [`RequestTypeLabel.layout.documents_delete_record`]: LabelTypeDeleteRecord,
-  [`RequestTypeLabel.layout.documents_publish_draft`]: LabelTypePublishRecord,
-  [`InvenioRequests.RequestTypeIcon.layout.documents_edit_record`]:
+  [`RequestTypeLabel.layout.edit-published-record`]: LabelTypeEditRecord,
+  [`RequestTypeLabel.layout.delete-published-record`]: LabelTypeDeleteRecord,
+  [`RequestTypeLabel.layout.publish-draft`]: LabelTypePublishRecord,
+  [`InvenioRequests.RequestTypeIcon.layout.edit-published-record`]:
     EditRecordIcon,
-  [`InvenioRequests.RequestTypeIcon.layout.documents_delete_record`]:
+  [`InvenioRequests.RequestTypeIcon.layout.delete-published-record`]:
     DeleteRecordIcon,
-  [`InvenioRequests.RequestTypeIcon.layout.documents_publish_draft`]:
-    PublishRecordIcon,
+  [`InvenioRequests.RequestTypeIcon.layout.publish-draft`]: PublishRecordIcon,
 };

--- a/oarepo_dashboard/ui/dashboard_requests/semantic-ui/js/dashboard_requests/search/index.js
+++ b/oarepo_dashboard/ui/dashboard_requests/semantic-ui/js/dashboard_requests/search/index.js
@@ -7,6 +7,7 @@ import {
   SearchappSearchbarElement,
   ActiveFiltersElement,
   ClearFiltersButton,
+  DynamicResultsListItem,
 } from "@js/oarepo_ui";
 import { withState } from "react-searchkit";
 import {
@@ -93,11 +94,15 @@ export const DashboardUploadsSearchLayout = UserDashboardSearchAppLayoutHOC({
   extraContent: FacetButtons,
   appName: overridableIdPrefix,
 });
+
+const DynamicRequestListItem = parametrize(DynamicResultsListItem, {
+  FallbackComponent: RequestsResultsItemTemplateDashboard,
+  selector: "type",
+});
 export const componentOverrides = {
   [`${overridableIdPrefix}.EmptyResults.element`]:
     RequestsEmptyResultsWithState,
-  [`${overridableIdPrefix}.ResultsList.item`]:
-    RequestsResultsItemTemplateDashboard,
+  [`${overridableIdPrefix}.ResultsList.item`]: DynamicRequestListItem,
   [`${overridableIdPrefix}.ActiveFilters.element`]:
     ActiveFiltersElementWIgnoredFilters,
   [`${overridableIdPrefix}.ClearFiltersButton.container`]: () => null,


### PR DESCRIPTION
Here is a proposal how to have different result list items in the requests search app (that are determined based on the request type. We use the dynamic list item and use current requests resultlistitem as a fallback. Then, in the app itself, in invenio.cfg, we can provide a variable that would be object, where keys are request types and values are a path to the result list item (relative to templates folder), something like this:

`REQUESTS_RESULT_LIST_ITEMS={"delete-published-record": "oarepo_vocabularies_ui/DeleteRecordRequest"}`

