### PR TITLE
fixed escaped rendering of strings coming from srvr

### DIFF
--- a/oarepo_dashboard/ui/dashboard_communities/__init__.py
+++ b/oarepo_dashboard/ui/dashboard_communities/__init__.py
@@ -5,6 +5,7 @@ from oarepo_ui.resources.resource import RecordsUIResource
 from flask_menu import current_menu
 from flask_login import login_required
 from oarepo_runtime.i18n import lazy_gettext as _
+from oarepo_ui.resources.components import AllowedHtmlTagsComponent
 
 
 class DashboardCommunitiesUIResourceConfig(RecordsUIResourceConfig):
@@ -14,8 +15,8 @@ class DashboardCommunitiesUIResourceConfig(RecordsUIResourceConfig):
     application_id = "communities_dashboard"
     templates = {
         "search": "DashboardCommunitiesPage",
-    }   
-
+    }
+    components = [AllowedHtmlTagsComponent]
     routes = {
         "search": "/",
     }
@@ -26,7 +27,6 @@ class DashboardCommunitiesUIResourceConfig(RecordsUIResourceConfig):
 
 
 class DashboardCommunitiesUIResource(RecordsUIResource):
-
     decorators = [
         login_required,
     ]

--- a/oarepo_dashboard/ui/dashboard_records/__init__.py
+++ b/oarepo_dashboard/ui/dashboard_records/__init__.py
@@ -9,6 +9,7 @@ from oarepo_ui.resources import PermissionsComponent
 from oarepo_dashboard.ui.dashboard_components.search import (
     DashboardRecordsSearchComponent,
 )
+from oarepo_ui.resources.components import AllowedHtmlTagsComponent
 
 
 class DashboardRecordsUIResourceConfig(GlobalSearchUIResourceConfig):
@@ -25,14 +26,17 @@ class DashboardRecordsUIResourceConfig(GlobalSearchUIResourceConfig):
     }
     api_service = "records"
 
-    components = [DashboardRecordsSearchComponent, PermissionsComponent]
+    components = [
+        DashboardRecordsSearchComponent,
+        PermissionsComponent,
+        AllowedHtmlTagsComponent,
+    ]
 
     def search_endpoint_url(self, identity, api_config, overrides={}, **kwargs):
         return "/api/user/search"
 
 
 class DashboardRecordsUIResource(GlobalSearchUIResource):
-
     decorators = [
         login_required,
     ]

--- a/oarepo_dashboard/ui/dashboard_requests/__init__.py
+++ b/oarepo_dashboard/ui/dashboard_requests/__init__.py
@@ -8,6 +8,7 @@ from oarepo_runtime.i18n import lazy_gettext as _
 from oarepo_dashboard.ui.dashboard_components.search import (
     DashboardRequestsSearchComponent,
 )
+from oarepo_ui.resources.components import AllowedHtmlTagsComponent
 
 
 class DashboardRequestsUIResourceConfig(RecordsUIResourceConfig):
@@ -24,7 +25,7 @@ class DashboardRequestsUIResourceConfig(RecordsUIResourceConfig):
     }
     api_service = "requests"
 
-    components = [DashboardRequestsSearchComponent]
+    components = [DashboardRequestsSearchComponent, AllowedHtmlTagsComponent]
 
     def search_endpoint_url(self, identity, api_config, overrides={}, **kwargs):
         return "/api/requests"

--- a/oarepo_dashboard/ui/dashboard_requests/semantic-ui/js/dashboard_requests/search/ComputerTabletRequestsListItem.jsx
+++ b/oarepo_dashboard/ui/dashboard_requests/semantic-ui/js/dashboard_requests/search/ComputerTabletRequestsListItem.jsx
@@ -63,10 +63,12 @@ export const ComputerTabletRequestsListItem = ({
             {i18next.t("Opened by {{creatorName}} on {{created}}.", {
               creatorName: creatorName,
               created: result.created,
+              interpolation: { escapeValue: false },
             })}{" "}
             {result.receiver &&
               i18next.t("Recepient: {{receiver}}.", {
                 receiver: result.receiver.label,
+                interpolation: { escapeValue: false },
               })}
           </small>
           <small className="right floated">

--- a/oarepo_dashboard/ui/dashboard_requests/semantic-ui/js/dashboard_requests/search/MobileRequestsListItem.jsx
+++ b/oarepo_dashboard/ui/dashboard_requests/semantic-ui/js/dashboard_requests/search/MobileRequestsListItem.jsx
@@ -58,10 +58,12 @@ export const MobileRequestsListItem = ({
             {i18next.t("Opened by {{creatorName}} on {{created}}.", {
               creatorName: creatorName,
               created: result.created,
+              interpolation: { escapeValue: false },
             })}{" "}
             {result.receiver &&
               i18next.t("Recepient: {{receiver}}.", {
                 receiver: result.receiver.label,
+                interpolation: { escapeValue: false },
               })}
           </small>
           <small className="block rel-mt-1">

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = oarepo-dashboard
-version = 1.0.12
+version = 1.0.13
 description = Support for user dashboard (records, communities, requests)
 authors = Mirek Simek <miroslav.simek@cesnet.cz>
 readme = README.md


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/364517fb-0af0-46f1-9357-f1f67a9a78e5)

it seems when you use string interpolation in i18next, it keeps the escaping (vs when you render that string inside of a cmp, the escaped chars get handled normally).