### PR TITLE
fixed taking permission from session

### DIFF
--- a/oarepo_dashboard/ui/dashboard_components/search.py
+++ b/oarepo_dashboard/ui/dashboard_components/search.py
@@ -1,5 +1,6 @@
 from oarepo_ui.resources.components import UIResourceComponent
-from flask import current_app, session
+from flask import current_app
+from oarepo_ui.utils import can_view_deposit_page
 
 
 class DashboardRecordsSearchComponent(UIResourceComponent):
@@ -8,7 +9,7 @@ class DashboardRecordsSearchComponent(UIResourceComponent):
             current_app.config.get("DASHBOARD_RECORD_CREATE_URL", "")
         )
         search_options["overrides"]["permissions"] = {
-            "can_create": session["view_deposit_page_permission"]
+            "can_create": can_view_deposit_page()
         }
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = oarepo-dashboard
-version = 1.0.15
+version = 1.0.16
 description = Support for user dashboard (records, communities, requests)
 authors = Mirek Simek <miroslav.simek@cesnet.cz>
 readme = README.md


### PR DESCRIPTION
@mirekys Ahoj, here is the fix to the issue. What I thought initially, is that we could somehow, fill the session with this permission on login, but it turned out to not quite be possible to do, due to the order of calls, i.e. the user identity may not be yet fully loaded to check the permission properly when this signal is triggered. I discussed also with Miro and it seems that indeed this is not possible to guarantee, so this is a reasonable alternative. Please take a look. Thanks