### PR TITLE
using new uploads/new path

### DIFF
--- a/oarepo_dashboard/ui/dashboard_components/templates/oarepo/invenio_app_rdm/users/header.html
+++ b/oarepo_dashboard/ui/dashboard_components/templates/oarepo/invenio_app_rdm/users/header.html
@@ -23,7 +23,7 @@
       </div>
     </div>
     {% if active_dashboard_menu_item == "uploads" %}
-      <a class="ui tiny button positive left labeled icon m-0" href="{{config.get("DASHBOARD_RECORD_CREATE_URL", "")}}">
+      <a class="ui tiny button positive left labeled icon m-0" href="{{config.get("DASHBOARD_RECORD_CREATE_URL", url_for('oarepo_ui.uploads_new'))}}">
         <i class="upload icon" aria-hidden="true"></i>
         {{ _('New upload') }}
       </a>

--- a/oarepo_dashboard/ui/dashboard_components/templates/oarepo/invenio_app_rdm/users/header.html
+++ b/oarepo_dashboard/ui/dashboard_components/templates/oarepo/invenio_app_rdm/users/header.html
@@ -23,7 +23,7 @@
       </div>
     </div>
     {% if active_dashboard_menu_item == "uploads" %}
-      <a class="ui tiny button positive left labeled icon m-0" href="{{config.get("DASHBOARD_RECORD_CREATE_URL", url_for('oarepo_ui.uploads_new'))}}">
+      <a class="ui tiny button positive left labeled icon m-0" href="{{ config.get('DASHBOARD_RECORD_CREATE_URL') or url_for('oarepo_ui.uploads_new') }}">
         <i class="upload icon" aria-hidden="true"></i>
         {{ _('New upload') }}
       </a>


### PR DESCRIPTION
Do not merge before we are sure that all repositories switch to oarepo-ui > = 7, because uploads/new does not exist before that version and url_for will crash in case variable not defined in invenio.cfg DASHBOARD_RECORD_CREATE_URL