### PR TITLE
Chore: major bump due to changes in invenio

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "oarepo-dashboard"
-version = "5.0.0"
+version = "6.0.0"
 description = "Support for user dashboard (records, communities, requests)"
 readme = "README.md"
 requires-python = ">=3.14,<3.15"
@@ -9,9 +9,9 @@ authors = [
 ]
 dependencies = [
     "oarepo[rdm,tests]>=14,<15",
-    "oarepo-runtime>=4.0.0,<5.0.0",
-    "oarepo-ui>=10.0.0,<11.0.0",
-    "oarepo-rdm>=4.0.0,<5.0.0",
+    "oarepo-runtime>=5.0.0,<6.0.0",
+    "oarepo-ui>=11.0.0,<12.0.0",
+    "oarepo-rdm>=6.0.0,<7.0.0",
     "cachetools",
     "openpyxl",
 


### PR DESCRIPTION
Major version bump due to major bump in packages: oarepo-runtime, oarepo-ui, oarepo-rdm.

## Included pull requests

- chore: removed oarepo-tools from dev dependencies ([#42](https://github.com/oarepo/oarepo-dashboard/pull/42))
