### PR TITLE
Major version bump due to major bump in invenio packages

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "oarepo-dashboard"
-version = "6.0.0"
+version = "7.0.0"
 description = "Support for user dashboard (records, communities, requests)"
 readme = "README.md"
 requires-python = ">=3.14,<3.15"
@@ -9,9 +9,9 @@ authors = [
 ]
 dependencies = [
     "oarepo[rdm,tests]>=14,<15",
-    "oarepo-runtime>=5.0.0,<6.0.0",
-    "oarepo-ui>=11.0.0,<12.0.0",
-    "oarepo-rdm>=6.0.0,<7.0.0",
+    "oarepo-runtime>=6.0.0,<7.0.0",
+    "oarepo-ui>=12.0.0,<13.0.0",
+    "oarepo-rdm>=7.0.0,<8.0.0",
     "cachetools",
     "openpyxl",
 


### PR DESCRIPTION
Major version bump due to major bump in packages: oarepo-runtime, oarepo-ui, oarepo-rdm.
